### PR TITLE
Add Forward.Fivers to serverlist

### DIFF
--- a/launcher/en/js/launcher.js
+++ b/launcher/en/js/launcher.js
@@ -1359,6 +1359,9 @@ function printSrvMsg(e) {
         case 'wild':
             addLogMsg("Wild Hunters Discord: /S2g97pTgAU", "y");
             break;
+        case 'f5g7':
+            addLogMsg("Forward.Fivers Discord: /dptGmF9xBd", "y");
+            break;
         case 'custom':
             addLogMsg("erupe.custom must be set in hosts!", "y");
             break;

--- a/serverlist.xml
+++ b/serverlist.xml
@@ -13,7 +13,7 @@
   <group idx='11' nam='Quick Hunt (US)' ip='35.133.218.93' port='53312' svid='quik' oauth_url='debug-www.mhf-g.com/console-link.html'/>
   <group idx='12' nam='DoomServer (RU)' ip='193.124.64.139' port='53312' svid='doom' oauth_url='debug-www.mhf-g.com/console-link.html'/>
   <group idx='13' nam='Wild Hunters (CU)' ip='152.206.201.134' port='53312' svid='wild' oauth_url='debug-www.mhf-g.com/console-link.html'/>
-  <group idx='14' nam=`Forward.Fivers (CA)' ip='129.153.57.148' port='53312' svid='fw5r' oauth_url='debug-www.mhf-g.com/console-link.html'/>
+  <group idx='14' nam='Forward.Fivers (CA)' ip='129.153.57.148' port='53312' svid='fw5r' oauth_url='debug-www.mhf-g.com/console-link.html'/>
   <!--group idx='98' nam='GG Test (AU)' ip='sek.ai' port='53312' svid='' oauth_url='debug-www.mhf-g.com/console-link.html'/-->
   <group idx='99' nam='Custom' ip='erupe.custom' port='53312' svid='custom' oauth_url='debug-www.mhf-g.com/console-link.html'/>
 </server_groups>

--- a/serverlist.xml
+++ b/serverlist.xml
@@ -13,6 +13,7 @@
   <group idx='11' nam='Quick Hunt (US)' ip='35.133.218.93' port='53312' svid='quik' oauth_url='debug-www.mhf-g.com/console-link.html'/>
   <group idx='12' nam='DoomServer (RU)' ip='193.124.64.139' port='53312' svid='doom' oauth_url='debug-www.mhf-g.com/console-link.html'/>
   <group idx='13' nam='Wild Hunters (CU)' ip='152.206.201.134' port='53312' svid='wild' oauth_url='debug-www.mhf-g.com/console-link.html'/>
+  <group idx='14' nam=`Forward.Fivers (CA)' ip='129.153.57.148' port='53312' svid='fw5r' oauth_url='debug-www.mhf-g.com/console-link.html'/>
   <!--group idx='98' nam='GG Test (AU)' ip='sek.ai' port='53312' svid='' oauth_url='debug-www.mhf-g.com/console-link.html'/-->
   <group idx='99' nam='Custom' ip='erupe.custom' port='53312' svid='custom' oauth_url='debug-www.mhf-g.com/console-link.html'/>
 </server_groups>


### PR DESCRIPTION
Please let me know if anything needs to be corrected. This is a Forward.5 compatible server only.

Set to draft only due to lack of support for retro servers.